### PR TITLE
fix: set nvim terminal colors to match kitty

### DIFF
--- a/lua/kitty-scrollback/configs/example.lua
+++ b/lua/kitty-scrollback/configs/example.lua
@@ -143,6 +143,9 @@ return {
       }
     end,
     [prefix .. 'highlight_overrides'] = function()
+      for i = 0, 15 do
+        vim.g['terminal_color_' .. i] = 'Cyan'
+      end
       return {
         highlight_overrides = {
           KittyScrollbackNvimNormal = {

--- a/lua/kitty-scrollback/highlights.lua
+++ b/lua/kitty-scrollback/highlights.lua
@@ -147,8 +147,9 @@ M.get_highlights_as_env = function()
   return env
 end
 
----Set nvim default highlights
+---Set nvim default highlights and terminal colors
 M.set_highlights = function()
+  -- set highlight groups
   local overrides = opts.highlight_overrides or {}
   for name, definition in pairs(highlight_definitions()) do
     vim.api.nvim_set_hl(0, name, definition)
@@ -157,8 +158,7 @@ M.set_highlights = function()
       vim.api.nvim_set_hl(0, name, override)
     end
   end
-
-  -- set terminal colors
+  -- set terminal colors (see :help terminal-config)
   for i = 0, 15 do
     vim.b['terminal_color_' .. i] = p.kitty_colors['color' .. i]
   end

--- a/lua/kitty-scrollback/highlights.lua
+++ b/lua/kitty-scrollback/highlights.lua
@@ -157,6 +157,11 @@ M.set_highlights = function()
       vim.api.nvim_set_hl(0, name, override)
     end
   end
+
+  -- set terminal colors
+  for i = 0, 15 do
+    vim.b['terminal_color_' .. i] = p.kitty_colors['color' .. i]
+  end
 end
 
 return M


### PR DESCRIPTION
- [x] add demo of issue with fix, occurs when using flags `--no-nvim-args` and overriding `vim.g.terminal_color_X`.

closes #49 