### PR TITLE
[WIP] Add tmux support

### DIFF
--- a/python/launch_tmux_scrollback.py
+++ b/python/launch_tmux_scrollback.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import inspect
+import subprocess
+import shlex
+
+ksb_dir = os.path.dirname(
+    os.path.dirname(os.path.abspath(inspect.getfile(lambda: None))))
+
+
+# Compare to the pipe_data fn in `kitty_scrollback_nvim.py`
+def pipe_data(target_window_id, window_title, pane_height, pane_width):
+    return {
+        'scrolled_by': 0,
+        'cursor_x': int(tmux_opt("cursor_x")) + 1,
+        'cursor_y': int(tmux_opt("cursor_y")) + 1,
+        'lines': pane_height,
+        'columns': pane_width,
+        'window_id': int(target_window_id),
+        'window_title': window_title,
+        'ksb_dir': ksb_dir,
+    }
+
+
+def tmux_opt(option):
+    output = subprocess.run([
+        "tmux",
+        "display-message",
+        "-p",
+        f"#{{{option}}}"
+    ], stdout=subprocess.PIPE, stderr=subprocess.PIPE).stdout.decode("utf-8")
+    return output.strip()
+
+
+def main():
+    target_window_id = tmux_opt("window_index")
+    window_title = tmux_opt("pane_title")
+    pane_height = int(tmux_opt("pane_height"))
+    pane_width = int(tmux_opt(("pane_width")))
+    kitty_data_str = pipe_data(target_window_id, window_title, pane_height, pane_width)
+    kitty_data = json.dumps(kitty_data_str)
+
+    if window_title.startswith('kitty-scrollback.nvim'):
+        print(
+            f'[Warning] kitty-scrollback.nvim: skipping action, window {target_window_id} has title that '
+            'starts with "kitty-scrollback.nvim"')
+        print(json.dumps(kitty_data_str, indent=2))
+        return
+
+    nvim_args = (
+        'nvim',
+        '--clean',
+        '--noplugin',
+        '-n',
+        '--cmd',
+        ' lua'
+        ' vim.api.nvim_create_autocmd([[VimEnter]], {'
+        '  group = vim.api.nvim_create_augroup([[KittyScrollBackNvimVimEnter]], { clear = true }),'
+        '  pattern = [[*]],'
+        '  callback = function()'
+        f'  vim.opt.runtimepath:append([[{ksb_dir}]])'
+        '   vim.api.nvim_exec_autocmds([[User]], { pattern = [[KittyScrollbackLaunch]], modeline = false })'
+        f'  require([[kitty-scrollback.launch]]).setup_and_launch([[{kitty_data}]])'
+        ' end,'
+        ' })')
+
+    subprocess.run([
+        'tmux',
+        'display-popup',
+        '-E',
+        '-B',
+        '-x', 'P',
+        '-y', 'P',
+        '-w', str(pane_width),
+        '-h', str(pane_height),
+        shlex.join(nvim_args)
+    ])
+
+
+main()


### PR DESCRIPTION
Hey, 

I saw your plugin after watching the talk you gave at Neovim Conf on YouTube. I thought it was a great idea, but unfortunately I don't use Kitty - but I do use tmux. I figured it might be possible to get your plugin running for tmux and saw there was even a recent issue that was opened asking for that feature (#115), so I gave it a shot. This is still very much a WIP, but the "front end" seems to work, i.e. getting data into the plugin and getting it to display everything correctly. The "backend" is completely missing still, so things like sending commands to be executed will just error at the moment. tbh I was testing this in WezTerm, but if you use tmux from within Kitty many more things might actually be working just fine. 

Similar to the kitty support, which seems to be mediated through the `kitty_scrollback_nvim.py` script, I've added a `launch_tmux_scrollback.py` script. This is intended to be the entrypoint from which the user sets up a keybinding within their tmux.conf, e.g.: 

```bash
bind e run-shell "$HOME/path/to/plugin/kitty-scrollback.nvim/python/launch_tmux_scrollback.py"
```

Remaining tasks/issues as I see them before this is ready:

- [ ] When the history contents are large (e.g. > few thousand lines) then the screen flashes when neovim starts
- [ ] Visual mode highlighting seems to be broken
- [ ] Add "additional nvim options" functionality to tmux launch script (e.g. load minimal plugin env instead of clean env) 
- [ ] Add/update tests
- [ ] Healthchecks / tmux version checks (launcher script requires >3.2 for the popup) 
- [ ] Update README