### PR TITLE
fix: wrong config merge operation

### DIFF
--- a/lua/kitty-scrollback/footer_win.lua
+++ b/lua/kitty-scrollback/footer_win.lua
@@ -34,7 +34,7 @@ M.footer_winopts = function(paste_winopts)
     style = 'minimal',
   }
 
-  if opts.paste_window.winopts_overrides then
+  if opts.paste_window.footer_winopts_overrides then
     footer_winopts = vim.tbl_deep_extend(
       'force',
       footer_winopts,


### PR DESCRIPTION
This makes the plugin try to merge `footer_winopts_overrides` when `winopts_overrides` exists, but `footer_winopts_overrides` may not exist.