### PR TITLE
doc: add start in the search mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,12 @@ alter all default shortcuts that use [kitty_mod](https://sw.kovidgoyal.net/kitty
   mouse_map ctrl+shift+right press ungrabbed combine : mouse_select_command_output : kitty_scrollback_nvim --config ksb_builtin_last_visited_cmd_output
   ```
 
+- Start in the search mode (Optional)
+  You can start to search the scrollback buffer immediately without to type the extra `?` key
+  ```sh
+  map kitty_mod+f kitty_scrollback_nvim --nvim-args -c 'call feedkeys("?")'
+  ```
+
 ## ⚙️ Configuration
 
 This section provides details on how to customize your kitty-scrollback.nvim configuration.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Navigate your [Kitty](https://sw.kovidgoyal.net/kitty/) scrollback buffer to qui
 > [!TIP]\
 > Expand each section under the [Features](#-features) section to see a demo.
 >
-> Check out [Advanced Configuration Examples](https://github.com/mikesmithgh/kitty-scrollback.nvim/wiki/Advanced-Configuration-Examples) for more demos! 
+> Check out the [wiki](https://github.com/mikesmithgh/kitty-scrollback.nvim/wiki) for 
+> [detailed demos of each configuration option](https://github.com/mikesmithgh/kitty-scrollback.nvim/wiki/Advanced-Configuration-Examples), [useful configurations](https://github.com/mikesmithgh/kitty-scrollback.nvim/wiki#useful-configurations), and more.
 
 <!-- panvimdoc-ignore-end -->
 
@@ -332,19 +333,13 @@ alter all default shortcuts that use [kitty_mod](https://sw.kovidgoyal.net/kitty
   mouse_map ctrl+shift+right press ungrabbed combine : mouse_select_command_output : kitty_scrollback_nvim --config ksb_builtin_last_visited_cmd_output
   ```
 
-- Start in the search mode (Optional)
-  You can start to search the scrollback buffer immediately without to type the extra `?` key
-  ```sh
-  map kitty_mod+f kitty_scrollback_nvim --nvim-args -c 'call feedkeys("?")'
-  ```
-
 ## ⚙️ Configuration
 
 This section provides details on how to customize your kitty-scrollback.nvim configuration.
 
 > [!NOTE]\
-> The [Advanced Configuration Examples](https://github.com/mikesmithgh/kitty-scrollback.nvim/wiki/Advanced-Configuration-Examples) section of the Wiki provides
-> detailed demos of each configuration option.
+> The [Advanced Configuration](https://github.com/mikesmithgh/kitty-scrollback.nvim/wiki#advanced-configuration) section of the wiki provides
+> [useful configurations](https://github.com/mikesmithgh/kitty-scrollback.nvim/wiki#useful-configurations) and [detailed demos of each configuration option](https://github.com/mikesmithgh/kitty-scrollback.nvim/wiki/Advanced-Configuration-Examples).
 
 ### Kitten Arguments
 Arguments that can be passed to the `kitty_scrollback_nvim` [Kitten](https://sw.kovidgoyal.net/kitty/kittens_intro/) defined in [kitty.conf](https://sw.kovidgoyal.net/kitty/conf/). You can provide 


### PR DESCRIPTION
This is convenient, put it in the README so that users don't need to search around to find it out.

Based [here](https://github.com/mikesmithgh/kitty-scrollback.nvim/issues/204)