### PR TITLE
fix: use root for cwd instead of current

### DIFF
--- a/python/kitty_scrollback_nvim.py
+++ b/python/kitty_scrollback_nvim.py
@@ -125,7 +125,7 @@ def parse_cwd(args):
             cwd_args = args[idx + 1]
             del args[idx:idx + 2]
             return ('--cwd', cwd_args)
-    return ('--cwd', 'current')
+    return ('--cwd', 'root')
 
 
 def nvim_err_cmd(err_file):


### PR DESCRIPTION
Using `current` causes issues over ssh, specifically when using
the `kitten +ssh` command. This is because it current cwd on
the remote machine may not exist on the local machine. `root`
uses the originating window instead of the overlay window
containing the remote connection.
