### PR TITLE
chore: refactor nvim version checkhealth

### DIFF
--- a/lua/kitty-scrollback/health.lua
+++ b/lua/kitty-scrollback/health.lua
@@ -180,13 +180,8 @@ M.nvim_version = function()
 end
 
 M.check_nvim_version = function(version, check_only)
-  local start = vim.health and (vim.health.start or vim.health.report_start)
-    or require('health').report_start
-  local error = vim.health and (vim.health.error or vim.health.report_error)
-    or require('health').report_error
-
   if not check_only then
-    start('kitty-scrollback: Neovim version 0.10+')
+    vim.health.start('kitty-scrollback: Neovim version 0.10+')
   end
   local nvim_version = 'NVIM ' .. M.nvim_version()
   if vim.fn.has(version) == 1 then
@@ -196,7 +191,7 @@ M.check_nvim_version = function(version, check_only)
     return true
   else
     if not check_only then
-      error(nvim_version, M.advice.nvim_version)
+      vim.health.error(nvim_version, M.advice.nvim_version)
     end
   end
   return false

--- a/lua/kitty-scrollback/health.lua
+++ b/lua/kitty-scrollback/health.lua
@@ -1,5 +1,7 @@
 ---@mod kitty-scrollback.health
-local M = {}
+local M = {
+  supported_nvim_version = 'nvim-0.10',
+}
 
 ---@type KsbPrivate
 local p
@@ -179,21 +181,27 @@ M.nvim_version = function()
   return fmt_version
 end
 
-M.check_nvim_version = function(version, check_only)
-  if not check_only then
-    vim.health.start('kitty-scrollback: Neovim version 0.10+')
+M.display_version_error = function()
+  local prompt_msg = 'kitty-scrollback.nvim: Fatal error, on version NVIM '
+    .. M.nvim_version()
+    .. '. '
+    .. table.concat(M.advice.nvim_version)
+  vim.fn.confirm(prompt_msg, '&Quit')
+end
+
+M.check_nvim_version = function()
+  if vim.fn.has('nvim-0.9.1') == 0 then
+    -- vim.health.start was introduced in 0.9.1, fallback to error on older versions of nvim
+    M.display_version_error()
+    return false
   end
+  vim.health.start('kitty-scrollback: Neovim version 0.10+')
   local nvim_version = 'NVIM ' .. M.nvim_version()
-  if vim.fn.has(version) == 1 then
-    if not check_only then
-      vim.health.ok(nvim_version)
-    end
+  if vim.fn.has(M.supported_nvim_version) == 1 then
+    vim.health.ok(nvim_version)
     return true
-  else
-    if not check_only then
-      vim.health.error(nvim_version, M.advice.nvim_version)
-    end
   end
+  vim.health.error(nvim_version, M.advice.nvim_version)
   return false
 end
 
@@ -263,7 +271,7 @@ end
 
 M.check = function()
   if
-    M.check_nvim_version('nvim-0.10')
+    M.check_nvim_version()
     and check_kitty_scrollback_nvim_version()
     and check_kitty_remote_control()
     and check_has_kitty_data()

--- a/lua/kitty-scrollback/launch.lua
+++ b/lua/kitty-scrollback/launch.lua
@@ -263,12 +263,8 @@ M.setup = function(kitty_data_str)
     vim.cmd('checkhealth kitty-scrollback') -- prefer vim.cmd('checkhealth') over vim.cmd.checkhealth to support older versions of neovim
     return
   end
-  if not ksb_health.check_nvim_version('nvim-0.10', true) then
-    local prompt_msg = 'kitty-scrollback.nvim: Fatal error, on version NVIM '
-      .. ksb_health.nvim_version()
-      .. '. '
-      .. table.concat(ksb_health.advice.nvim_version)
-    vim.fn.confirm(prompt_msg, '&Quit')
+  if vim.fn.has(ksb_health.supported_nvim_version) == 0 then
+    ksb_health.display_version_error()
     ksb_util.quitall()
   end
   if not ksb_health.check_kitty_version(true) then


### PR DESCRIPTION
Simplify the health check as Neovim 0.10+ is anyway targeted. `vim.health.report_start` and `vim.health.report_error` were deprecated in 0.10