### PR TITLE
chore: add type annotation to setup

### DIFF
--- a/lua/kitty-scrollback/configs/builtin.lua
+++ b/lua/kitty-scrollback/configs/builtin.lua
@@ -1,4 +1,4 @@
----@type table<string, KsbOpts|fun(KsbKittyData):KsbOpts>
+---@type table<string, KsbOpts|fun(KsbKittyData):KsbOpts?>
 return {
   ksb_builtin_get_text_all = {
     kitty_get_text = {

--- a/lua/kitty-scrollback/configs/defaults.lua
+++ b/lua/kitty-scrollback/configs/defaults.lua
@@ -19,16 +19,16 @@
 ---@field extent string|nil | 'screen' | 'all' | 'selection' | 'first_cmd_output_on_screen' | 'last_cmd_output' | 'last_visited_cmd_output' | 'last_non_empty_output'     What text to get. The default of screen means all text currently on the screen. all means all the screen+scrollback and selection means the currently selected text. first_cmd_output_on_screen means the output of the first command that was run in the window on screen. last_cmd_output means the output of the last command that was run in the window. last_visited_cmd_output means the first command output below the last scrolled position via scroll_to_prompt. last_non_empty_output is the output from the last command run in the window that had some non empty output. The last four require shell_integration to be enabled. Choices: screen, all, first_cmd_output_on_screen, last_cmd_output, last_non_empty_output, last_visited_cmd_output, selection
 
 ---@class KsbStatusWindowIcons
----@field kitty string kitty status window icon, defaults to 󰄛
----@field heart string heart status window icon, defaults to 󰣐
----@field nvim string nvim status window icon, defaults to 
+---@field kitty? string kitty status window icon, defaults to 󰄛
+---@field heart? string heart status window icon, defaults to 󰣐
+---@field nvim? string nvim status window icon, defaults to 
 
 ---@class KsbStatusWindowOpts
----@field enabled boolean If true, show status window in upper right corner of the screen
----@field style_simple boolean If true, use plaintext instead of nerd font icons
----@field autoclose boolean If true, close the status window after kitty-scrollback.nvim is ready
----@field show_timer boolean If true, show a timer in the status window while kitty-scrollback.nvim is loading
----@field icons KsbStatusWindowIcons Icons displayed in the status window, defaults to 󰄛 󰣐 
+---@field enabled? boolean If true, show status window in upper right corner of the screen
+---@field style_simple? boolean If true, use plaintext instead of nerd font icons
+---@field autoclose? boolean If true, close the status window after kitty-scrollback.nvim is ready
+---@field show_timer? boolean If true, show a timer in the status window while kitty-scrollback.nvim is loading
+---@field icons? KsbStatusWindowIcons Icons displayed in the status window, defaults to 󰄛 󰣐 
 
 ---@alias BoolOrFn boolean|fun():boolean
 ---@alias KsbWinOpts table<string, any>

--- a/lua/kitty-scrollback/init.lua
+++ b/lua/kitty-scrollback/init.lua
@@ -4,7 +4,6 @@ local M = {}
 ---@type table<string, KsbOpts|fun(KsbKittyData):KsbOpts>
 M.configs = {}
 
----Create commands for generating kitty-scrollback.nvim kitten configs
 ---@param configs? table<string, KsbOpts|fun(KsbKittyData):KsbOpts>
 M.setup = function(configs)
   if configs then

--- a/lua/kitty-scrollback/init.lua
+++ b/lua/kitty-scrollback/init.lua
@@ -5,6 +5,7 @@ local M = {}
 M.configs = {}
 
 ---Create commands for generating kitty-scrollback.nvim kitten configs
+---@param configs? table<string, KsbOpts|fun(KsbKittyData):KsbOpts>
 M.setup = function(configs)
   if configs then
     M.configs = configs

--- a/lua/kitty-scrollback/init.lua
+++ b/lua/kitty-scrollback/init.lua
@@ -1,10 +1,10 @@
 ---@mod kitty-scrollback
 local M = {}
 
----@type table<string, KsbOpts|fun(KsbKittyData):KsbOpts>
+---@type table<string, KsbOpts|fun(KsbKittyData):KsbOpts?>
 M.configs = {}
 
----@param configs? table<string, KsbOpts|fun(KsbKittyData):KsbOpts>
+---@param configs? table<string, KsbOpts|fun(KsbKittyData):KsbOpts?>
 M.setup = function(configs)
   if configs then
     M.configs = configs


### PR DESCRIPTION
Add one missing type annotation in `lua/kitty-scrollback/init.lua`