### PR TITLE
Use literal CR and ESC bytes for bsd and busybox sed compatibility

### DIFF
--- a/lua/kitty-scrollback/health.lua
+++ b/lua/kitty-scrollback/health.lua
@@ -110,16 +110,18 @@ local function check_sed()
     return
   end
 
+  local esc = vim.fn.eval([["\e"]]) -- literal ESC byte, matches the portable command used to read the scrollback
+  local cr = vim.fn.eval([["\r"]]) -- literal CR byte
   local cmd = {
     'sed',
     '-E',
     '-e',
-    [[s/\r//g]],
+    's/' .. cr .. '//g',
     '-e',
-    [[s/$/\x1b[0m/g]],
+    's/$/' .. esc .. '[0m/g',
   }
   local ok, sed_proc = pcall(vim.system, cmd, {
-    stdin = 'expected\r',
+    stdin = 'expected' .. cr,
   })
   local result = {}
   if ok then
@@ -129,7 +131,6 @@ local function check_sed()
     result.stdout = ''
     result.stderr = sed_proc
   end
-  local esc = vim.fn.eval([["\e"]]) -- use ^[ instead of \x1b to pass healthcheck
   ok = ok and result.code == 0 and result.stdout == 'expected' .. esc .. '[0m'
   if ok then
     vim.health.ok(

--- a/lua/kitty-scrollback/kitty_commands.lua
+++ b/lua/kitty-scrollback/kitty_commands.lua
@@ -29,9 +29,10 @@ local function get_scrollback_cmd(get_text_args)
     p.kitty_data.window_id,
     get_text_args.kitty
   )
-  local sed_cmd = [[sed -E ]]
-    .. [[-e 's/\r//g' ]] -- added to remove /r added by --add-wrap-markers, (--add-wrap-markers is used to add empty lines at end of screen)
-    .. [[-e 's/$/\x1b[0m/g']] -- append all lines with reset to avoid unintended colors
+  -- embed literal CR and ESC bytes rather than the \r and \x1b escapes, which only gnu sed expands (bsd and busybox sed pass them through literally)
+  local sed_cmd = "sed -E "
+    .. "-e 's/\r//g' " -- remove CR added by --add-wrap-markers, which adds empty lines at end of screen
+    .. "-e 's/$/\x1b[0m/g'" -- append all lines with reset to avoid unintended colors
   local flush_stdout_cmd = p.kitty_data.kitty_path .. [[ +runpy 'sys.stdout.flush()']]
   local full_cmd = scrollback_cmd .. ' | ' .. sed_cmd .. ' && ' .. flush_stdout_cmd
   if vim.fn.has('nvim-0.12') == 0 then


### PR DESCRIPTION
Once switching to alpine linux I noticed that kitty-scrollback stopped working correctly since it has busybox sed.
I have only tried this fix on alpine linux so testing with GNU sed should we done before merging.