### PR TITLE
fix: substitute <Bslash> with \ in footer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
           - 'stable'  # v0.12.+
           - 'nightly' 
         kitty_version: 
-          - 'stable'  # 0.46.+
+          - 'stable'  # 0.48.+
           - 'nightly'
         # update __branch-protection-rules.json and run __update_branch_protection_rules.sh when modified
         # test only latest patch versions of nvim released as of v0.10.0
@@ -49,17 +49,19 @@ jobs:
             kitty_version: 'stable'
           - nvim_version: 'v0.11.7'
             kitty_version: 'stable'
-          - nvim_version: 'v0.12.2'
+          - nvim_version: 'v0.12.4'
             kitty_version: 'stable'
           # nvim stable + kitty versions
-          - nvim_version: 'stable'
-            kitty_version: '0.43.0'
           - nvim_version: 'stable'
             kitty_version: '0.43.1'
           - nvim_version: 'stable'
             kitty_version: '0.44.0'
           - nvim_version: 'stable'
             kitty_version: '0.45.0'
+          - nvim_version: 'stable'
+            kitty_version: '0.46.2'
+          - nvim_version: 'stable'
+            kitty_version: '0.47.4'
       fail-fast: false
     runs-on: ubuntu-24.04
     steps:

--- a/lua/kitty-scrollback/footer_win.lua
+++ b/lua/kitty-scrollback/footer_win.lua
@@ -15,6 +15,10 @@ M.setup = function(private, options)
   opts = options ---@diagnostic disable-line: unused-local
 end
 
+local keytrans_display = function(keys)
+  return vim.fn.keytrans(keys):gsub('<lt>', '<'):gsub('<Bslash>', '\\')
+end
+
 M.footer_winopts = function(paste_winopts)
   local target_border = { '▏', ' ', '▕', '▕', '🭿', '▁', '🭼', '▏' }
   local row_offset = 1
@@ -96,7 +100,7 @@ M.open_footer_window = function(winopts, refresh_only)
   )
 
   local default_footer_keys = {
-    ['<Plug>(KsbNormalYank)'] = vim.fn.keytrans((vim.g.mapleader or '\\') .. 'y'):gsub('<lt>', '<'),
+    ['<Plug>(KsbNormalYank)'] = keytrans_display((vim.g.mapleader or '\\') .. 'y'),
     ['<Plug>(KsbExecuteCmd)'] = '<C-CR>',
     ['<Plug>(KsbPasteCmd)'] = '<S-CR>',
     ['<Plug>(KsbToggleFooter)'] = 'g?',
@@ -113,7 +117,7 @@ M.open_footer_window = function(winopts, refresh_only)
   for _, km in pairs(mapped_to_ksb_keymaps) do
     local rhs = km.rhs
     if footer_keys[rhs] ~= nil then
-      local lhs = vim.fn.keytrans(km.lhs):gsub('<lt>', '<')
+      local lhs = keytrans_display(km.lhs)
       if not footer_keys[rhs] or (footer_keys[rhs] and lhs ~= default_footer_keys[rhs]) then
         footer_keys[rhs] = lhs
       end

--- a/scripts/internal/__branch-protection-rules.json
+++ b/scripts/internal/__branch-protection-rules.json
@@ -12,11 +12,12 @@
       "plenary (v0.10.0, stable)",
       "plenary (v0.10.4, stable)",
       "plenary (v0.11.7, stable)",
-      "plenary (v0.12.2, stable)",
-      "plenary (stable, 0.43.0)",
+      "plenary (v0.12.4, stable)",
       "plenary (stable, 0.43.1)",
       "plenary (stable, 0.44.0)",
-      "plenary (stable, 0.45.0)"
+      "plenary (stable, 0.45.0)",
+      "plenary (stable, 0.46.2)",
+      "plenary (stable, 0.47.4)"
     ]
   },
   "enforce_admins": false,


### PR DESCRIPTION
The latest version of Neovim changed the behavior of keytrans for //. It now prints <Bslash> instead of \. Lets just convert it for consistency with tests and previous versions of Neovim. 